### PR TITLE
Update to support Ecto 3.5

### DIFF
--- a/lib/schemata.ex
+++ b/lib/schemata.ex
@@ -13,6 +13,7 @@ defmodule Schemata do
       def cast(_), do: :error
       def dump(_), do: :error
       def load(_), do: :error
+      def equal?(_, _), do: false
     end
   end
 

--- a/lib/schemata.ex
+++ b/lib/schemata.ex
@@ -14,6 +14,7 @@ defmodule Schemata do
       def dump(_), do: :error
       def load(_), do: :error
       def equal?(_, _), do: false
+      def embed_as(_), do: :error
     end
   end
 

--- a/lib/schemata.ex
+++ b/lib/schemata.ex
@@ -7,14 +7,14 @@ defmodule Schemata do
       import Schemata.Queries
       import Ecto.Query
       import Ecto.Changeset
-      
+
       @behaviour Ecto.Type
       def type, do: :schemata_virtual_type
       def cast(_), do: :error
       def dump(_), do: :error
       def load(_), do: :error
       def equal?(_, _), do: false
-      def embed_as(_), do: :error
+      def embed_as(_), do: :dump
     end
   end
 
@@ -327,7 +327,7 @@ defmodule Schemata do
       @doc """
       Accepts data and params, and returns either:
       - an instance of this type with the params applied
-      - an `t:errors/0` map, which maps from field names to error messages, or maps 
+      - an `t:errors/0` map, which maps from field names to error messages, or maps
 
       When called, aliases are expanded. If params contains multiple aliased
       fields which can resolve to the same field, the one which wins is

--- a/lib/schemata.ex
+++ b/lib/schemata.ex
@@ -7,6 +7,12 @@ defmodule Schemata do
       import Schemata.Queries
       import Ecto.Query
       import Ecto.Changeset
+      
+      @behaviour Ecto.Type
+      def type, do: :schemata_virtual_type
+      def cast(_), do: :error
+      def dump(_), do: :error
+      def load(_), do: :error
     end
   end
 


### PR DESCRIPTION
This pull request resolves an error as described here https://github.com/elixir-ecto/ecto/issues/3396 where Ecto rejects a schema that references another schema as defined by Schemata. Ecto 3.5 actually validates that the types used in a schema are proper Ecto types, as defined by the behavior `Ecto.Type`.

As we have no intention of _using_ a Schemata type in Ecto, I've merely stubbed the callbacks that Ecto requires in order to get it to believe that it's working with real Ecto types so we can continue hijacking its validation behaviors unimpeded.